### PR TITLE
Update docker image tag naming convention

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
           # Docker Hub uses lowercase so use a bashism to convert.
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
           # Docker tags can use only some special characters.
-          echo "COMMIT_ID=$(echo "${BRANCH_NAME}" | tr -C '0-9a-zA-Z._' '-')${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "COMMIT_ID=$(echo "${BRANCH_NAME}" | tr -C '0-9a-zA-Z._' '-')-${GITHUB_SHA}" >> $GITHUB_ENV
 
       - name: Pull previous image to support caching
         run: docker pull $IMAGE_NAME:latest || >&2 echo "Previous image not found"
@@ -39,7 +39,7 @@ jobs:
       - name: Build docker image for distribution
         run: docker build --cache-from=$IMAGE_NAME:latest -t $IMAGE_NAME:latest .
 
-      - name: Tag docker image as '<branch_name>-<git_commit_sha>'
+      - name: Tag docker image as '<branch_name>--<git_commit_sha>'
         run: docker tag $IMAGE_NAME:latest $IMAGE_NAME:$COMMIT_ID
 
       - name: Login to Docker Hub


### PR DESCRIPTION
Use two dashes `--` instead of one `-` separating branch name
and git commit hash in docker image names, as our convention seems
to be in other branches.

In other words, tag docker images like
`<branch name>--<git commit hash>` instead of
`<branch name>-<git commit hash>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-mbtiles-server/3)
<!-- Reviewable:end -->
